### PR TITLE
Render envValueFrom before env in generic chart

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 2.2.0
+version: 2.2.1

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -51,13 +51,13 @@ spec:
           {{- end }}
           {{- if or .Values.env .Values.envValueFrom }}
           env:
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
             {{- range $key, $value := .Values.envValueFrom }}
             - name: {{ $key }}
               valueFrom: {{- $value | toYaml | nindent 16 }}
+            {{- end }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
             {{- end }}
           {{- end }}
           {{- if or .Values.persistence.enabled .Values.additionalVolumeMounts }}


### PR DESCRIPTION
It is possible to use other env variables in a variable but only already defined variables.
This is almost only useful if you need to template a normal env variable with the value from a variable from a secret. To make this work it is important that the envValueFrom variables which can load a variable from a secret are rendered before the env variables.