### PR TITLE
Add support for storageclassname in generic chart

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 2.2.1
+version: 2.3.0

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -68,6 +68,7 @@ If you have environment variables set from ConfigMaps or Secrets, check out `env
 | nodeSelector | object | `{}` |  |
 | persistence.enabled | bool | `false` |  |
 | persistence.storage | string | `"100Mi"` |  |
+| persistence.storageClassName | string | `nil` | Set a storageClassName, otherwise the default class is used. |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | ports[0].containerPort | int | `80` |  |

--- a/charts/generic/templates/pvc.yaml
+++ b/charts/generic/templates/pvc.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.storage }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -63,6 +63,8 @@ annotations: {}
 persistence:
   enabled: false
   storage: 100Mi
+  # -- Set a storageClassName, otherwise the default class is used.
+  storageClassName: ~
 
 ports:
   - name: http


### PR DESCRIPTION
This already includes the commit from https://github.com/morremeyer/charts/pull/5 to avoid merge conflicts with the chart version after the other PR is merged.

I did not find a way to document the commented option in the values.yaml with helm-docs. Do you have any idea how to solve this in a better way?