### PR TITLE
Quote backup and cleanup schedules

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: backup
 description: Chart to back up PVCs with restic and regularly clean up the snapshots.
 type: application
-version: 1.0.2
+version: 1.0.3

--- a/charts/backup/templates/cronjob-backup.yaml
+++ b/charts/backup/templates/cronjob-backup.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "backup.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.backupJob.schedule }}
+  schedule: {{ .Values.backupJob.schedule | quote }}
   jobTemplate:
     spec:
       template:

--- a/charts/backup/templates/cronjob-cleanup.yaml
+++ b/charts/backup/templates/cronjob-cleanup.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "backup.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.cleanupJob.schedule }}
+  schedule: {{ .Values.cleanupJob.schedule | quote }}
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
To be honest, it is a bit of an obscure use-case to run this each minute.
But if the schedule starts with an * helm fails with
"error converting YAML to JSON: yaml: line 11: did not find expected alphabetic or numeric character".
This is solved by always quoting the schedule.