### PR TITLE
Set concurrencyPolicy of CronJobs

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: backup
 description: Chart to back up PVCs with restic and regularly clean up the snapshots.
 type: application
-version: 1.0.3
+version: 2.0.0

--- a/charts/backup/README.md
+++ b/charts/backup/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the chart and the defau
 | backupJob.backup.image.repository | string | `"restic/restic"` |  |
 | backupJob.backup.image.tag | string | `"0.12.0"` |  |
 | backupJob.backup.resources | object | `{}` | resources for the backup container |
+| backupJob.concurrencyPolicy | string | `"Forbid"` | concurrencyPolicy for the backup Jobs |
 | backupJob.init | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"restic/restic","tag":"0.12.0"},"resources":{}}` | Configuration for the repository init container |
 | backupJob.init.resources | object | `{}` | resources for the init container |
 | backupJob.nodeSelector | object | `{}` |  |
@@ -50,6 +51,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cleanupJob.affinity | object | `{}` |  |
 | cleanupJob.args | list | `[]` | arguments for the cleanup. **Automatically generated, only set when necessary** |
 | cleanupJob.command | string | `nil` | command for the cleanup. Defaults to '/usr/bin/restic' by the upstream container. |
+| cleanupJob.concurrencyPolicy | string | `"Forbid"` | concurrencyPolicy for the cleanup Jobs |
 | cleanupJob.enabled | bool | `true` | If backups shall be cleaned up after some time |
 | cleanupJob.image.pullPolicy | string | `"IfNotPresent"` |  |
 | cleanupJob.image.repository | string | `"restic/restic"` |  |

--- a/charts/backup/templates/cronjob-backup.yaml
+++ b/charts/backup/templates/cronjob-backup.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "backup.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.backupJob.schedule | quote }}
+  concurrencyPolicy: {{ .Values.backupJob.concurrencyPolicy }}
   jobTemplate:
     spec:
       template:

--- a/charts/backup/templates/cronjob-cleanup.yaml
+++ b/charts/backup/templates/cronjob-cleanup.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "backup.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.cleanupJob.schedule | quote }}
+  concurrencyPolicy: {{ .Values.cleanupJob.concurrencyPolicy }}
   jobTemplate:
     spec:
       template:

--- a/charts/backup/values.yaml
+++ b/charts/backup/values.yaml
@@ -14,6 +14,9 @@ backupJob:
   # -- when to run backups
   schedule: "17 3 * * *"
 
+  # -- concurrencyPolicy for the backup Jobs
+  concurrencyPolicy: Forbid
+
   # -- restartPolicy for the backup Jobs
   restartPolicy: OnFailure
 
@@ -72,6 +75,9 @@ cleanupJob:
 
   # -- number of yearly snapshots to keep
   keepYearly: 2
+
+  # -- concurrencyPolicy for the cleanup Jobs
+  concurrencyPolicy: Forbid
 
   # -- restartPolicy for the cleanup Jobs
   restartPolicy: OnFailure


### PR DESCRIPTION
Allow to specify the concurrecnyPolicy for the backup and cleanup Jobs.
The default of Kubernetes is "Allow" but I think for this chart it makes sense
to set the default to "Forbid".
Bumped the major version because this is kind of an breaking change, even though
it probably breaks nothing.