### PR TITLE
Add static labels to the pods

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: backup
 description: Chart to back up PVCs with restic and regularly clean up the snapshots.
 type: application
-version: 2.0.0
+version: 2.1.0

--- a/charts/backup/templates/cronjob-backup.yaml
+++ b/charts/backup/templates/cronjob-backup.yaml
@@ -10,6 +10,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            {{- include "backup.selectorLabels" . | nindent 14 }}
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/backup/templates/cronjob-cleanup.yaml
+++ b/charts/backup/templates/cronjob-cleanup.yaml
@@ -11,6 +11,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            {{- include "backup.selectorLabels" . | nindent 14 }}
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:


### PR DESCRIPTION
Currently the pods only have some dynamic labels which makes
it impossible to apply network policies to the pods.
By adding the selector labels as static labels we end up with
some static labels we can use for network policies (or other pod selectors).