### PR TITLE
Make successfulJobsHistoryLimit and failedJobsHistoryLimit configurable

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: backup
 description: Chart to back up PVCs with restic and regularly clean up the snapshots.
 type: application
-version: 2.1.0
+version: 2.2.0

--- a/charts/backup/README.md
+++ b/charts/backup/README.md
@@ -41,18 +41,21 @@ The following table lists the configurable parameters of the chart and the defau
 | backupJob.backup.image.tag | string | `"0.12.0"` |  |
 | backupJob.backup.resources | object | `{}` | resources for the backup container |
 | backupJob.concurrencyPolicy | string | `"Forbid"` | concurrencyPolicy for the backup Jobs |
+| backupJob.failedJobsHistoryLimit | int | `1` | failedJobsHistoryLimit for the backup Jobs |
 | backupJob.init | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"restic/restic","tag":"0.12.0"},"resources":{}}` | Configuration for the repository init container |
 | backupJob.init.resources | object | `{}` | resources for the init container |
 | backupJob.nodeSelector | object | `{}` |  |
 | backupJob.restartPolicy | string | `"OnFailure"` | restartPolicy for the backup Jobs |
 | backupJob.schedule | string | `"17 3 * * *"` | when to run backups |
 | backupJob.securityContext | object | `{}` |  |
+| backupJob.successfulJobsHistoryLimit | int | `3` | successfulJobsHistoryLimit for the backup Jobs |
 | backupJob.tolerations | list | `[]` |  |
 | cleanupJob.affinity | object | `{}` |  |
 | cleanupJob.args | list | `[]` | arguments for the cleanup. **Automatically generated, only set when necessary** |
 | cleanupJob.command | string | `nil` | command for the cleanup. Defaults to '/usr/bin/restic' by the upstream container. |
 | cleanupJob.concurrencyPolicy | string | `"Forbid"` | concurrencyPolicy for the cleanup Jobs |
 | cleanupJob.enabled | bool | `true` | If backups shall be cleaned up after some time |
+| cleanupJob.failedJobsHistoryLimit | int | `1` | failedJobsHistoryLimit for the cleanup Jobs |
 | cleanupJob.image.pullPolicy | string | `"IfNotPresent"` |  |
 | cleanupJob.image.repository | string | `"restic/restic"` |  |
 | cleanupJob.image.tag | string | `"0.12.0"` |  |
@@ -65,6 +68,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cleanupJob.restartPolicy | string | `"OnFailure"` | restartPolicy for the cleanup Jobs |
 | cleanupJob.schedule | string | `"17 15 * * *"` | when to run the cleanup |
 | cleanupJob.securityContext | object | `{}` |  |
+| cleanupJob.successfulJobsHistoryLimit | int | `3` | successfulJobsHistoryLimit for the cleanup Jobs |
 | cleanupJob.tolerations | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/backup/templates/cronjob-backup.yaml
+++ b/charts/backup/templates/cronjob-backup.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   schedule: {{ .Values.backupJob.schedule | quote }}
   concurrencyPolicy: {{ .Values.backupJob.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backupJob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backupJob.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/charts/backup/templates/cronjob-cleanup.yaml
+++ b/charts/backup/templates/cronjob-cleanup.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   schedule: {{ .Values.cleanupJob.schedule | quote }}
   concurrencyPolicy: {{ .Values.cleanupJob.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.cleanupJob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cleanupJob.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/charts/backup/values.yaml
+++ b/charts/backup/values.yaml
@@ -32,6 +32,12 @@ backupJob:
 
   securityContext: {}
 
+  # -- successfulJobsHistoryLimit for the backup Jobs
+  successfulJobsHistoryLimit: 3
+
+  # -- failedJobsHistoryLimit for the backup Jobs
+  failedJobsHistoryLimit: 1
+
   backup:
     image:
       repository: restic/restic
@@ -103,3 +109,9 @@ cleanupJob:
   affinity: {}
 
   securityContext: {}
+
+  # -- successfulJobsHistoryLimit for the cleanup Jobs
+  successfulJobsHistoryLimit: 3
+
+  # -- failedJobsHistoryLimit for the cleanup Jobs
+  failedJobsHistoryLimit: 1


### PR DESCRIPTION
Keeping four jobs/pods for each backup target uses up quite a bit of
space in the cluster. By making it configurable the users can reduce
the overhead if wanted.