### PR TITLE
feat(cronjob)update default command, args. Remove support for incoming traffic

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 1.1.4
+version: 2.0.0
 maintainers:
   - name: morre
     email: charts@mor.re

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -10,6 +10,23 @@ Run jobs on a schedule
 | ---- | ------ | --- |
 | morre | charts@mor.re |  |
 
+## Upgrading
+
+### To 2.0.0
+
+Support for the following has been removed:
+
+* `livenessProbe`
+* `readinessProbe`
+* `ports`
+
+This is a design decision as CronJobs should not have any incoming traffic.
+
+The following default values have been changed:
+
+* `command` from `["/bin/echo"]` to `[]`
+* `args` from `["'{"level": "info", "message": "no arguments defined, nothing to do"}'"]` to `[]`
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -18,8 +35,8 @@ Run jobs on a schedule
 | additionalVolumes | list | `[]` |  |
 | affinity | object | `{}` | affinity object for the pod |
 | annotations | object | `{}` |  |
-| args | list | `["{\"level\": \"info\", \"message\": \"no arguments defined, nothing to do\"}"]` | arguments to pass to the command or binary being run |
-| command | list | `["/bin/echo"]` | the command or binary to run |
+| args | list | `[]` | arguments to pass to the command or binary being run |
+| command | list | `[]` | the command or binary to run |
 | env | list | `[]` | Directly set environment variables |
 | envValueFrom | object | `{}` | Set environment variables from configMaps or Secrets |
 | failedJobsHistoryLimit | string | `nil` | The number of failed finished jobs to retain. |

--- a/charts/cronjob/README.md.gotmpl
+++ b/charts/cronjob/README.md.gotmpl
@@ -7,4 +7,22 @@
 {{ template "chart.maintainersSection" . }}
 {{ template "chart.sourcesSection" . }}
 {{ template "chart.requirementsSection" . }}
+
+## Upgrading
+
+### To 2.0.0
+
+Support for the following has been removed:
+
+* `livenessProbe`
+* `readinessProbe`
+* `ports`
+
+This is a design decision as CronJobs should not have any incoming traffic.
+
+The following default values have been changed:
+
+* `command` from `["/bin/echo"]` to `[]`
+* `args` from `["'{"level": "info", "message": "no arguments defined, nothing to do"}'"]` to `[]`
+
 {{ template "chart.valuesSection" . }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -77,16 +77,6 @@ spec:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
               {{- end }}
-              {{- with .Values.ports }}
-              ports:
-                {{- toYaml . | nindent 16 }}
-              {{- end }}
-              {{- with .Values.livenessProbe }}
-              livenessProbe: {{- toYaml . | nindent 16 }}
-              {{- end }}
-              {{- with .Values.readinessProbe }}
-              readinessProbe: {{- toYaml . | nindent 16 }}
-              {{- end }}
               {{- with .Values.resources }}
               resources: {{- toYaml .Values.resources | nindent 16 }}
               {{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -41,12 +41,10 @@ podSecurityContext: {}
 securityContext: {}
 
 # -- the command or binary to run
-command: ["/bin/echo"]
+command: []
 
 # -- arguments to pass to the command or binary being run
-args:
-  - '{"level": "info", "message": "no arguments defined, nothing to do"}'
-
+args: []
 
 # -- Directly set environment variables
 env: []


### PR DESCRIPTION
See the updated README.md for explanations.

The default command and args are set to empty so that you don't need to specify them if you want to run the default command and args of the image you're using.