### PR TITLE
docs: add Code of Conduct, Security information, and contribution guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+charts@mor.re.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Pull requests are welcome here. Please keep the [Code of Conduct](CODE_OF_CONDUCT.md) in mind when contributing.
+
+## Opening issues
+
+Please describe the problem or your suggestion as detailed as possible when opening an issue.
+
+## Development
+
+Before you commit, please run pre-commit. This will also generate the documentation for the helm charts.
+
+To set up pre-commit to run automatically on commit, run (example for Ubuntu)
+
+```sh
+pip3 install pre-commit
+
+pre-commit install
+```
+
+### Commit messages
+
+This repository uses [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure all your commit messages follow this syntax to enable people to quickly check what a commit does.
+
+Valid commit types are defined in [commitizen/conventional-commit-types](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json).
+
+### Versioning
+
+Helm charts use semantic versioning. For the charts in this repository, only `[MAJOR].[MINOR].[PATCH]` syntax is used, without any pre-releases.
+
+Please bump as follows:
+
+* Major version for breaking changes (this includes updates of default values as users may need to manually update their values)
+* Minor version when you add features
+* Patch version for bug fixes and documentation updates

--- a/README.md
+++ b/README.md
@@ -2,38 +2,13 @@
 
 This repository contains all charts that I use throughout my infrastructure that weren’t already built by someone else.
 
-**Pull requests are welcome.**
+Pull requests are welcome, check [CONTRIBUTING.md](CONTRIBUTING.md) for detailed information.
 
 ## Usage
 
 ```sh
 helm repo add morre https://morremeyer.github.io/charts/
+
+# Install a cronjob with the cronjob chart. Fill the my-cron-values.yaml file before running this!
+helm install cronjob morre/cronjob --values my-cron-values.yaml
 ```
-
-## Development
-
-Before you commit, please run pre-commit. This will also generate the documentation for the helm charts.
-
-To set up pre-commit to run automatically on commit, run (example for Ubuntu)
-
-```sh
-pip3 install pre-commit
-
-pre-commit install
-```
-
-### Commit messages
-
-This repository uses [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure all your commit messages follow this syntax to enable people to quickly check what a commit does.
-
-Valid commit types are defined in [commitizen/conventional-commit-types](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json).
-
-### Versioning
-
-Helm charts use semantic versioning. For the charts in this repository, only `[MAJOR].[MINOR].[PATCH]` syntax is used, without any pre-releases.
-
-Please bump as follows:
-
-* Major version for breaking changes (this includes updates of default values as users may need to manually update their values)
-* Minor version when you add features
-* Patch version for bug fixes and documentation updates

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not open an issue if you find a vulnerability. Send an email to `charts@mor.me` and
+a maintainer will get in touch with you as soon as possible. This might take up to 72 hours.
+
+We will keep you up to date with all developments via email.
+
+Once we checked your report and confirmed the vulnerability, we'll patch it as soon as possible and issue a security advisory afterwards.


### PR DESCRIPTION
This brings the repositories documentation up to current standards.