### PR TITLE
feat: use maps instead of lists

### DIFF
--- a/charts/namespaces/Chart.yaml
+++ b/charts/namespaces/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: namespaces
 description: Deploy namespaces with (default) networkpolicies
 type: application
-version: 1.1.1
+version: 2.0.0
 maintainers:
   - name: morre
     email: charts@mor.re
+  - name: ekeih

--- a/charts/namespaces/README.md
+++ b/charts/namespaces/README.md
@@ -1,6 +1,6 @@
 # namespaces
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Deploy namespaces with (default) networkpolicies
 
@@ -9,6 +9,7 @@ Deploy namespaces with (default) networkpolicies
 | Name | Email | Url |
 | ---- | ------ | --- |
 | morre | charts@mor.re |  |
+| ekeih |  |  |
 
 ## Example
 
@@ -16,6 +17,40 @@ Deploy namespaces with (default) networkpolicies
 # Disable all NetworkPolicies
 disableNetworkPolicies: false
 
+defaultNetworkPolicies:
+  # Deny all egress traffic
+  default-policy:
+    spec:
+      podSelector:
+        matchLabels:
+          role: db
+      policyTypes:
+        - Egress
+
+namespaces:
+  test:
+    labels:
+      meta.mor.re/testlabel: hallo
+    networkPolicies:
+      testpolicy:
+        spec:
+          podSelector:
+            matchLabels:
+              role: db
+
+  no-policies:
+    disableDefaultNetworkPolicies: true
+```
+
+## Upgrading
+
+### To 2.0.0
+
+The format to define namespaces and network policies has changed. Previously both were specified as a `list` with a `name` key. With this release a `map` is used instead with the name as key. This makes it possible to split the values into several files and merge them with helm.
+
+Old:
+
+```yaml
 defaultNetworkPolicies:
   # Deny all egress traffic
   - name: default-policy
@@ -36,15 +71,37 @@ namespaces:
           podSelector:
             matchLabels:
               role: db
+```
 
-  - name: no-policies
-    disableDefaultNetworkPolicies: true
+New:
+
+```yaml
+defaultNetworkPolicies:
+  # Deny all egress traffic
+  default-policy:
+    spec:
+      podSelector:
+        matchLabels:
+          role: db
+      policyTypes:
+        - Egress
+
+namespaces:
+  test:
+    labels:
+      meta.mor.re/testlabel: hallo
+    networkPolicies:
+      testpolicy:
+        spec:
+          podSelector:
+            matchLabels:
+              role: db
 ```
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| defaultNetworkPolicies | list | `[]` | NetworkPolicies that will be applied to all namespaces |
+| defaultNetworkPolicies | object | `{}` | NetworkPolicies that will be applied to all namespaces |
 | disableNetworkPolicies | bool | `false` | Switch to disable all NetworkPolicies |
-| namespaces | list | `[]` | List of namespaces to deploy |
+| namespaces | object | `{}` | List of namespaces to deploy |

--- a/charts/namespaces/README.md.gotmpl
+++ b/charts/namespaces/README.md.gotmpl
@@ -16,6 +16,40 @@ disableNetworkPolicies: false
 
 defaultNetworkPolicies:
   # Deny all egress traffic
+  default-policy:
+    spec:
+      podSelector:
+        matchLabels:
+          role: db
+      policyTypes:
+        - Egress
+
+namespaces:
+  test:
+    labels:
+      meta.mor.re/testlabel: hallo
+    networkPolicies:
+      testpolicy:
+        spec:
+          podSelector:
+            matchLabels:
+              role: db
+
+  no-policies:
+    disableDefaultNetworkPolicies: true
+```
+
+## Upgrading
+
+### To 2.0.0
+
+The format to define namespaces and network policies has changed. Previously both were specified as a `list` with a `name` key. With this release a `map` is used instead with the name as key. This makes it possible to split the values into several files and merge them with helm.
+
+Old:
+
+```yaml
+defaultNetworkPolicies:
+  # Deny all egress traffic
   - name: default-policy
     spec:
       podSelector:
@@ -34,9 +68,31 @@ namespaces:
           podSelector:
             matchLabels:
               role: db
+```
 
-  - name: no-policies
-    disableDefaultNetworkPolicies: true
+New:
+
+```yaml
+defaultNetworkPolicies:
+  # Deny all egress traffic
+  default-policy:
+    spec:
+      podSelector:
+        matchLabels:
+          role: db
+      policyTypes:
+        - Egress
+
+namespaces:
+  test:
+    labels:
+      meta.mor.re/testlabel: hallo
+    networkPolicies:
+      testpolicy:
+        spec:
+          podSelector:
+            matchLabels:
+              role: db
 ```
 
 {{ template "chart.valuesSection" . }}

--- a/charts/namespaces/templates/namespace.yaml
+++ b/charts/namespaces/templates/namespace.yaml
@@ -1,10 +1,10 @@
 {{- $labels := include "namespaces.labels" . -}}
-{{- range $.Values.namespaces }}
+{{- range $name, $v := $.Values.namespaces }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .name }}
+  name: {{ $name }}
   annotations:
     helm.sh/resource-policy: keep
   labels:

--- a/charts/namespaces/templates/networkpolicy.yaml
+++ b/charts/namespaces/templates/networkpolicy.yaml
@@ -1,31 +1,30 @@
 {{ if not .Values.disableNetworkPolicies }}
-{{- range $.Values.namespaces }}
-{{- $namespaceName := .name -}}
-{{- if not .disableDefaultNetworkPolicies -}}
-{{- range $.Values.defaultNetworkPolicies }}
+{{- range $namespaceName, $namespaceValues := $.Values.namespaces }}
+{{- if not $namespaceValues.disableDefaultNetworkPolicies -}}
+{{- range $defaultNetworkPolicyName, $defaultNetworkPolicy := $.Values.defaultNetworkPolicies }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .name }}
+  name: {{ $defaultNetworkPolicyName }}
   namespace: {{ $namespaceName }}
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  {{- toYaml .spec | nindent 2}}
+  {{- toYaml $defaultNetworkPolicy.spec | nindent 2}}
 {{- end }}
 {{- end }}
-{{- range .networkPolicies }}
+{{- range $networkPolicyName, $networkPolicy := $namespaceValues.networkPolicies }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .name }}
+  name: {{ $networkPolicyName }}
   namespace: {{ $namespaceName }}
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  {{- toYaml .spec | nindent 2}}
+  {{- toYaml $networkPolicy.spec | nindent 2}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/namespaces/values.yaml
+++ b/charts/namespaces/values.yaml
@@ -1,8 +1,8 @@
 # -- List of namespaces to deploy
-namespaces: []
+namespaces: {}
 
 # -- NetworkPolicies that will be applied to all namespaces
-defaultNetworkPolicies: []
+defaultNetworkPolicies: {}
 
 # -- Switch to disable all NetworkPolicies
 disableNetworkPolicies: false


### PR DESCRIPTION
Lists can not be merged which forces users to define all namespaces and
policies in a single file. This gets chaotic really fast. By replacing the
lists with maps we make it possible to merge several values files into
one.

This is a breaking change which requires every user to change their
values. An upgrade guide is included in the README.