### PR TITLE
fix: make cronjob chart compatible with 1.20

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 2.0.1
+version: 2.0.2
 maintainers:
   - name: morremeyer
     email: charts@mor.re

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "batch/v1" }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
 {{- else -}}
 apiVersion: batch/v1beta1


### PR DESCRIPTION
The capability check we were using so far did not work as `batch/v1` includes `batch/v1beta1`.