### PR TITLE
fix: always checkout HEAD ref

### DIFF
--- a/.github/workflows/helm-docs-pre-commit.yml
+++ b/.github/workflows/helm-docs-pre-commit.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
       - uses: actions/setup-go@v2
         with:
           # renovate: go-version
@@ -36,6 +39,9 @@ jobs:
       - helm-docs
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/lint-and-release.yml
+++ b/.github/workflows/lint-and-release.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Set up Helm
@@ -40,6 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Configure Git


### PR DESCRIPTION
This should fix the weird

```
Error: fatal: You are not currently on a branch. To push the history leading to the current (detached HEAD) state now, use git push origin HEAD:<name-of-remote-branch>
```

Errors we're getting in some actions.