### PR TITLE
fix: checkout head ref

### DIFF
--- a/.github/workflows/helm-docs-crd-updates-pre-commit.yml
+++ b/.github/workflows/helm-docs-crd-updates-pre-commit.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
       - uses: actions/setup-go@v2
         with:
           # renovate: go-version


### PR DESCRIPTION
We also need to checkout the HEAD ref for helm-docs. Why? I don't know. But if we don't, git lies to us and claims we're not on a branch.