### PR TITLE
test: relax commit linting to PR titles only

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,2 +1,2 @@
-commitsOnly: true
+titleOnly: true
 allowMergeCommits: false


### PR DESCRIPTION
This will relax the Semantic Pull Request check to only validate the PR title.

I would like to merge this together with updating the repository settings to allow squash merging only.

By this, we will get the PR title as commit message title, the person merging can decide upon the commit message body (by default, it’s all commit messages combined if there is multiple commits or just the original commit message if it’s only one commit).

What you think, @ekeih?
