### PR TITLE
feat: add ConfigMap support for static configuration

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 2.0.5
+version: 2.1.0
 maintainers:
   - name: morremeyer
     email: charts@mor.re

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -33,6 +33,22 @@ envValueFrom:
       key: user
 ```
 
+### configMap
+
+If you want to pass yaml as a value, you need to specify it in block style:
+
+```yaml
+configMap:
+  enabled: true
+  data:
+    config.yml: |
+      foo: bar
+      map:
+        list:
+          - foo
+          - bar
+```
+
 ## Upgrading
 
 ### To 2.0.0
@@ -60,6 +76,10 @@ The following default values have been changed:
 | annotations | object | `{}` |  |
 | args | list | `[]` | arguments to pass to the command or binary being run |
 | command | list | `[]` | the command or binary to run |
+| configMap.data | object | `{}` | The data for the ConfigMap. Both keys and values need to be strings. |
+| configMap.enabled | bool | `false` | If a ConfigMap with configurable values should be created |
+| configMap.mountFiles | list | `[]` | Mounting of individual keys in the ConfigMap as files |
+| configMap.mountPath | string | `""` | If specified, the ConfigMap is mounted as a directory at this path |
 | env | list | `[]` | Directly set environment variables |
 | envValueFrom | object | `{}` | Set environment variables from configMaps or Secrets |
 | failedJobsHistoryLimit | string | `nil` | The number of failed finished jobs to retain. |

--- a/charts/cronjob/README.md.gotmpl
+++ b/charts/cronjob/README.md.gotmpl
@@ -31,6 +31,22 @@ envValueFrom:
       key: user
 ```
 
+### configMap
+
+If you want to pass yaml as a value, you need to specify it in block style:
+
+```yaml
+configMap:
+  enabled: true
+  data:
+    config.yml: |
+      foo: bar
+      map:
+        list:
+          - foo
+          - bar
+```
+
 ## Upgrading
 
 ### To 2.0.0

--- a/charts/cronjob/templates/configmap.yaml
+++ b/charts/cronjob/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.configMap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cronjob.fullname" . }}
+  labels:
+    {{- include "cronjob.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.configMap.data }}
+  {{ $key }}: |
+    {{- $value | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -67,11 +67,22 @@ spec:
                   valueFrom: {{- $value | toYaml | nindent 20 }}
                 {{- end }}
               {{- end }}
-              {{- if or .Values.persistence.enabled .Values.additionalVolumeMounts }}
+              {{- if or .Values.persistence.enabled .Values.additionalVolumeMounts .Values.configMap.mountPath .Values.configMap.mountFiles }}
               volumeMounts:
                 {{- if .Values.persistence.enabled }}
                 - name: data
                   mountPath: {{ .Values.persistence.mountPath }}
+                {{- end }}
+                {{- with .Values.configMap.mountPath }}
+                - name: configmap
+                  mountPath: {{ . }}
+                  readOnly: true
+                {{- end }}
+                {{- range $file := .Values.configMap.mountFiles }}
+                - name: configmap
+                  mountPath: {{ .mountPath }}
+                  subPath: {{ .subPath }}
+                  readOnly: true
                 {{- end }}
               {{- with .Values.additionalVolumeMounts }}
                 {{- toYaml . | nindent 16 }}
@@ -89,7 +100,7 @@ spec:
           {{- with .Values.tolerations }}
           tolerations: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.persistence.enabled .Values.additionalVolumes }}
+          {{- if or .Values.persistence.enabled .Values.additionalVolumes .Values.configMap.mountPath .Values.configMap.mountFiles }}
           volumes:
             {{- if .Values.persistence.enabled }}
             - name: data
@@ -98,5 +109,10 @@ spec:
             {{- end }}
             {{- with .Values.additionalVolumes }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if or .Values.configMap.mountPath .Values.configMap.mountFiles }}
+            - name: configmap
+              configMap:
+                name: {{ include "cronjob.fullname" . }}
             {{- end }}
           {{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -60,6 +60,21 @@ labels: {}
 
 annotations: {}
 
+configMap:
+  # -- If a ConfigMap with configurable values should be created
+  enabled: false
+
+  # -- The data for the ConfigMap. Both keys and values need to be strings.
+  data: {}
+
+  # -- If specified, the ConfigMap is mounted as a directory at this path
+  mountPath: ""
+
+  # -- Mounting of individual keys in the ConfigMap as files
+  mountFiles: []
+    # - subPath: "config.yml"
+    #   mountPath: /app/config.yml
+
 persistence:
   enabled: false
 


### PR DESCRIPTION
This adds support for a ConfigMap with configurable content to be used for e.g. a config file for a tool running as CronJob.
