### PR TITLE
feat: implement support for restic repositories accessed via sftp

### DIFF
--- a/charts/backup/README.md
+++ b/charts/backup/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the chart and the defau
 | backupJob.securityContext | object | `{}` |  |
 | backupJob.successfulJobsHistoryLimit | int | `3` | successfulJobsHistoryLimit for the backup Jobs |
 | backupJob.tolerations | list | `[]` |  |
+| cleanupJob.additionalVolumeMounts | list | `[]` | Additional volumes to mount to the restic container, e.g. to backup hostPaths. |
 | cleanupJob.affinity | object | `{}` |  |
 | cleanupJob.args | list | `[]` | arguments for the cleanup. **Automatically generated, only set when necessary** |
 | cleanupJob.command | string | `nil` | command for the cleanup. Defaults to '/usr/bin/restic' by the upstream container. |
@@ -89,3 +90,5 @@ The following table lists the configurable parameters of the chart and the defau
 | pvc | string | `nil` |  |
 | repo | string | `nil` | The repository location |
 | secretName | string | `"backup-secret"` | The secret that all containers load their environment from. See https://restic.readthedocs.io/en/latest/040_backup.html#environment-variables for variables. |
+| sftpConfig.knownHosts | list | `[]` | # Mounted as ConfigMap to /etc/ssh/ssh_known_hosts |
+| sftpConfig.privateKeys.fromSecret | string | `nil` | # secret mounted to /root/.ssh/ |

--- a/charts/backup/templates/cronjob-backup.yaml
+++ b/charts/backup/templates/cronjob-backup.yaml
@@ -33,12 +33,35 @@ spec:
             args:
               - -c
               - "restic -r {{ .Values.repo }} unlock || restic -r {{ .Values.repo }} init"
+            {{- with .Values.backupJob.env }}
+            env:
+              {{- toYaml . | nindent 14}}
+            {{- end }}
             envFrom:
               - secretRef:
                   name: {{ .Values.secretName }}
             {{- with .Values.backupJob.init.resources }}
             resources:
               {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- if or .Values.pvc .Values.backupJob.backup.additionalVolumeMounts .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.fromSecret}}
+            volumeMounts:
+            {{- end }}
+            {{- if .Values.pvc }}
+              - mountPath: "/data"
+                name: data
+            {{- end }}
+            {{- if .Values.sftpConfig.knownHosts }}
+              - mountPath: "/etc/ssh/ssh_known_hosts"
+                name: sftp-known-hosts
+                subPath: known_hosts
+            {{- end }}
+            {{- if .Values.sftpConfig.privateKeys.fromSecret }}
+              - mountPath: "/root/.ssh"
+                name: sftp-private-keys
+            {{- end }}
+            {{- if .Values.backupJob.backup.additionalVolumeMounts }}
+              {{- toYaml .Values.backupJob.backup.additionalVolumeMounts | nindent 14 }}
             {{- end }}
           containers:
           - name: backup
@@ -74,12 +97,21 @@ spec:
             resources:
               {{- toYaml . | nindent 14 }}
             {{- end }}
-            {{- if or .Values.pvc .Values.backupJob.backup.additionalVolumeMounts }}
+            {{- if or .Values.pvc .Values.backupJob.backup.additionalVolumeMounts .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.fromSecret}}
             volumeMounts:
             {{- end }}
             {{- if .Values.pvc }}
               - mountPath: "/data"
                 name: data
+            {{- end }}
+            {{- if .Values.sftpConfig.knownHosts }}
+              - mountPath: "/etc/ssh/ssh_known_hosts"
+                name: sftp-known-hosts
+                subPath: known_hosts
+            {{- end }}
+            {{- if .Values.sftpConfig.privateKeys.fromSecret }}
+              - mountPath: "/root/.ssh/"
+                name: sftp-private-keys
             {{- end }}
             {{- if .Values.backupJob.backup.additionalVolumeMounts }}
               {{- toYaml .Values.backupJob.backup.additionalVolumeMounts | nindent 14 }}
@@ -107,13 +139,24 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.pvc .Values.backupJob.additionalVolumes }}
+          {{- if or .Values.pvc .Values.backupJob.additionalVolumes .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.fromSecret}}
           volumes:
+          {{- end }}
+          {{- if .Values.sftpConfig.knownHosts }}
+            - name: sftp-known-hosts
+              configMap:
+                name: {{ include "backup.fullname" . }}-known-hosts
           {{- end }}
           {{- if .Values.pvc }}
             - name: data
               persistentVolumeClaim:
                 claimName: {{ .Values.pvc }}
+          {{- end }}
+          {{- if .Values.sftpConfig.privateKeys.fromSecret }}
+            - name: sftp-private-keys
+              secret:
+                secretName: {{ .Values.sftpConfig.privateKeys.fromSecret }}
+                defaultMode: 0400
           {{- end }}
           {{- if .Values.backupJob.additionalVolumes }}
             {{- toYaml .Values.backupJob.additionalVolumes | nindent 12 }}

--- a/charts/backup/templates/cronjob-cleanup.yaml
+++ b/charts/backup/templates/cronjob-cleanup.yaml
@@ -34,12 +34,35 @@ spec:
             args:
               - -c
               - "restic -r {{ .Values.repo }} unlock"
+            {{- with .Values.cleanupJob.env }}
+            env:
+              {{- toYaml . | nindent 14}}
+            {{- end }}
             envFrom:
               - secretRef:
                   name: {{ .Values.secretName }}
             {{- with .Values.cleanupJob.resources }}
             resources:
               {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- if or .Values.pvc .Values.cleanupJob.additionalVolumeMounts .Values.cleanupJob.additionalVolumeMounts .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.fromSecret}}
+            volumeMounts:
+            {{- end }}
+            {{- if .Values.pvc }}
+              - mountPath: "/data"
+                name: data
+            {{- end }}
+            {{- if .Values.sftpConfig.knownHosts }}
+              - mountPath: "/etc/ssh/ssh_known_hosts"
+                name: sftp-known-hosts
+                subPath: known_hosts
+            {{- end }}
+            {{- if .Values.sftpConfig.privateKeys.fromSecret }}
+              - mountPath: "/root/.ssh"
+                name: sftp-private-keys
+            {{- end }}
+            {{- if .Values.cleanupJob.additionalVolumeMounts }}
+              {{- toYaml .Values.cleanupJob.additionalVolumeMounts | nindent 14 }}
             {{- end }}
           containers:
           - name: cleanup
@@ -77,9 +100,32 @@ spec:
             envFrom:
               - secretRef:
                   name: {{ .Values.secretName }}
+            {{- with .Values.cleanupJob.env }}
+            env:
+              {{- toYaml . | nindent 14}}
+            {{- end }}
             {{- with .Values.cleanupJob.resources }}
             resources:
               {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- if or .Values.pvc .Values.cleanupJob.additionalVolumeMounts .Values.cleanupJob.additionalVolumeMounts .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.fromSecret}}
+            volumeMounts:
+            {{- end }}
+            {{- if .Values.pvc }}
+              - mountPath: "/data"
+                name: data
+            {{- end }}
+            {{- if .Values.sftpConfig.knownHosts }}
+              - mountPath: "/etc/ssh/ssh_known_hosts"
+                name: sftp-known-hosts
+                subPath: known_hosts
+            {{- end }}
+            {{- if .Values.sftpConfig.privateKeys.fromSecret }}
+              - mountPath: "/root/.ssh/"
+                name: sftp-private-keys
+            {{- end }}
+            {{- if .Values.cleanupJob.additionalVolumeMounts }}
+              {{- toYaml .Values.cleanupJob.additionalVolumeMounts | nindent 14 }}
             {{- end }}
           restartPolicy: {{ .Values.cleanupJob.restartPolicy }}
           {{- with .Values.cleanupJob.nodeSelector }}
@@ -102,5 +148,27 @@ spec:
           {{- with .Values.cleanupJob.tolerations }}
           tolerations:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.pvc .Values.cleanupJob.additionalVolumes .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.fromSecret }}
+          volumes:
+          {{- end }}
+          {{- if .Values.sftpConfig.knownHosts }}
+            - name: sftp-known-hosts
+              configMap:
+                name: {{ include "backup.fullname" . }}-known-hosts
+          {{- end }}
+          {{- if .Values.pvc }}
+            - name: data
+              persistentVolumeClaim:
+                claimName: {{ .Values.pvc }}
+          {{- end }}
+          {{- if .Values.sftpConfig.privateKeys.fromSecret }}
+            - name: sftp-private-keys
+              secret:
+                secretName: {{ .Values.sftpConfig.privateKeys.fromSecret }}
+                defaultMode: 0400
+          {{- end }}
+          {{- if .Values.cleanupJob.additionalVolumes }}
+            {{- toYaml .Values.cleanupJob.additionalVolumes | nindent 12 }}
           {{- end }}
 {{- end }}

--- a/charts/backup/templates/sftp-known_hosts.yaml
+++ b/charts/backup/templates/sftp-known_hosts.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sftpConfig.knownHosts -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "backup.fullname" . }}-known-hosts
+  namespace: {{ .Release.namespace }}
+  labels:
+    {{- include "backup.labels" . | nindent 4 }}
+data:
+  known_hosts: |
+    {{- range .Values.sftpConfig.knownHosts }}
+    {{ . | indent 2 | trim }}
+    {{- end }}
+{{- end }}

--- a/charts/backup/values.yaml
+++ b/charts/backup/values.yaml
@@ -13,6 +13,13 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+sftpConfig:
+  # -- # Mounted as ConfigMap to /etc/ssh/ssh_known_hosts
+  knownHosts: []
+  privateKeys:
+    # -- # secret mounted to /root/.ssh/
+    fromSecret: ~
+
 backupJob:
   # -- Additional environment values to load. Only applies to the backup container, not the init containers that initializes the restic repository. Has to match the pod.spec.containers.env spec.
   env: []
@@ -113,6 +120,9 @@ cleanupJob:
 
   # -- resources for the cleanup container
   resources: {}
+
+  # -- Additional volumes to mount to the restic container, e.g. to backup hostPaths.
+  additionalVolumeMounts: []
 
   nodeSelector: {}
 


### PR DESCRIPTION
This provides a way of configuring resources for sftp-repositories using ppk-auth.

Contians a fix for env-variables configured in values to be deployed in the backup- and cleanup-jobs.