### PR TITLE
feat: add support to configure restic compression

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backup
 description: Chart to back up PVCs with restic and regularly clean up the snapshots.
 type: application
-version: 2.9.0
+version: 2.10.0
 maintainers:
   - name: morremeyer
     email: charts@mor.re

--- a/charts/backup/README.md
+++ b/charts/backup/README.md
@@ -1,6 +1,6 @@
 # backup
 
-![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart to back up PVCs with restic and regularly clean up the snapshots.
 
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the chart and the defau
 | cleanupJob.securityContext | object | `{}` |  |
 | cleanupJob.successfulJobsHistoryLimit | int | `3` | successfulJobsHistoryLimit for the cleanup Jobs |
 | cleanupJob.tolerations | list | `[]` |  |
+| compression | string | `nil` | compression mode (only available for repository format version 2), one of (auto|off|max) |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |

--- a/charts/backup/templates/cronjob-backup.yaml
+++ b/charts/backup/templates/cronjob-backup.yaml
@@ -54,6 +54,10 @@ spec:
             {{- else }}
               - --no-cache
               - --verbose
+              {{- if .Values.compression }}
+              - --compression
+              - {{ .Values.compression }}
+              {{- end }}
               - --repo
               - {{ .Values.repo }}
               - backup

--- a/charts/backup/templates/cronjob-cleanup.yaml
+++ b/charts/backup/templates/cronjob-cleanup.yaml
@@ -55,6 +55,10 @@ spec:
             {{- else }}
               - --no-cache
               - --verbose
+              {{- if .Values.compression }}
+              - --compression
+              - {{ .Values.compression }}
+              {{- end }}
               - --group-by
               - paths
               - --repo

--- a/charts/backup/values.yaml
+++ b/charts/backup/values.yaml
@@ -2,6 +2,9 @@
 repo: ~
 pvc: ~
 
+# -- compression mode (only available for repository format version 2), one of (auto|off|max)
+compression: ~
+
 # -- The secret that all containers load their environment from. See https://restic.readthedocs.io/en/latest/040_backup.html#environment-variables for variables.
 secretName: "backup-secret"
 


### PR DESCRIPTION
With restic 0.14.0 it supports compression. The default level is auto
but it is possible to override it via `--compression (auto|max|off)`.