### PR TITLE
test: install changed charts with chart-testing

### DIFF
--- a/.github/workflows/lint-and-release.yml
+++ b/.github/workflows/lint-and-release.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  lint:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,13 +29,28 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.0
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ct.yaml
 
   release:
     if: ${{ github.ref == 'refs/heads/main' }}
     needs:
-      - lint
+      - lint-and-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Install changed charts with chart-testing action to verify that they work.

@ekeih I already updated the branch protection for the changed job name so that everything's green here.