### PR TITLE
feat: enable configuration of multiple ports

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 3.6.0
+version: 3.7.0
 maintainers:
   - name: morremeyer
-    email: charts@mor.re
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.7.0](https://img.shields.io/badge/Version-3.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 
@@ -8,7 +8,7 @@ A chart for generic applications. Use this if you need to deploy something witho
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| morremeyer | <charts@mor.re> |  |
+| morremeyer |  |  |
 | ekeih |  |  |
 
 ## Complex values
@@ -143,10 +143,11 @@ If you have environment variables set from ConfigMaps or Secrets, check out `env
 | service.annotations | object | `{}` |  |
 | service.ip | string | `nil` |  |
 | service.loadBalancerIP | string | `nil` |  |
-| service.name | string | `"http"` |  |
-| service.port | int | `80` |  |
-| service.protocol | string | `"TCP"` |  |
-| service.targetPort | string | `"http"` |  |
+| service.name | string | `"http"` | DEPRECATED: Use service.ports[*].name. Name of the port on the service. Ignored if service.ports is specified. |
+| service.port | int | `80` | DEPRECATED: Use service.ports[*].port. Port to use on the service. Ignored if service.ports is specified. |
+| service.ports | list | `[]` | List of ports. If you override it, you will have to explicitly add the default again. |
+| service.protocol | string | `"TCP"` | DEPRECATED: Use service.ports[*].protocol. Protocol to use for the target port. Ignored if service.ports is specified. |
+| service.targetPort | string | `"http"` | DEPRECATED: Use service.ports[*].targetPort. Target port on the pod. Ignored if service.ports is specified. |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/charts/generic/templates/service.yaml
+++ b/charts/generic/templates/service.yaml
@@ -11,10 +11,19 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+  {{- /* Include the deprecated settings if .Values.service.ports is empty */}}
+  {{- if not .Values.service.ports }}
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: {{ .Values.service.protocol }}
       name: {{ .Values.service.name }}
+  {{- end }}
+  {{- range .Values.service.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol }}
+      name: {{ .name }}
+  {{- end }}
   selector:
     {{- include "generic.selectorLabels" . | nindent 4 }}
   {{- if and (eq .Values.service.type "ClusterIP") (.Values.service.ip) }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -100,10 +100,22 @@ startupProbe: ~
 service:
   type: ClusterIP
   annotations: {}
+
+  # -- DEPRECATED: Use service.ports[*].targetPort. Target port on the pod. Ignored if service.ports is specified.
   targetPort: http
+  # -- DEPRECATED: Use service.ports[*].protocol. Protocol to use for the target port. Ignored if service.ports is specified.
   protocol: TCP
+  # -- DEPRECATED: Use service.ports[*].name. Name of the port on the service. Ignored if service.ports is specified.
   name: http
+  # -- DEPRECATED: Use service.ports[*].port. Port to use on the service. Ignored if service.ports is specified.
   port: 80
+
+  # -- List of ports. If you override it, you will have to explicitly add the default again.
+  ports: []  # TODO: Add default port and documentation.
+    # - targetPort: http
+    #   protocol: TCP
+    #   name: http
+    #   port: 80
 
   # Only for type ClusterIP
   ip: ~


### PR DESCRIPTION
:warning: Depends on #114 being merged first.

This adds a new `.Values.service.ports` array that will become the default in future versions. 
Deprecates `.Values.service.[targetPort|protocol|name|port]`.
