### PR TITLE
chore: drop support for old versions

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 3.8.0
+version: 4.0.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 3.8.0](https://img.shields.io/badge/Version-3.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 
@@ -10,6 +10,10 @@ A chart for generic applications. Use this if you need to deploy something witho
 | ---- | ------ | --- |
 | morremeyer |  |  |
 | ekeih |  |  |
+
+## Upgrading
+
+See [the upgrading instructions](UPGRADING.md) for upgrades with breaking changes.
 
 ## Complex values
 
@@ -50,39 +54,6 @@ configMap:
           - bar
 ```
 
-## Upgrading
-
-### To 3.0.0
-
-Support for CronJobs has been removed. If you used the `isCronjob: true` flag, please migrate to `morremeyer/cronjob` in version `2.0.0 <= x < 3.0.0`.
-
-:warning: If you need open ports on your CronJob pod, this is not supported in the cronjob chart. This is a design decision as CronJobs should not have any incoming traffic.
-
-The cronjob chart is almost fully compatible with all existing configuration you have (except for `ports`), you just have to do one migration step:
-
-1. Remove the `isCronjob: true` value
-
-### To 2.0.0
-
-The format for configuration environment variables has changed and is now less verbose.
-
-Old:
-
-```yaml
-env:
-  - name: ENV_NAME
-    value: test
-```
-
-New:
-
-```yaml
-env:
-  ENV_NAME: test
-```
-
-If you have environment variables set from ConfigMaps or Secrets, check out `envValueFrom`, which was [added in 1.1.0](https://github.com/morremeyer/charts/commit/a2b767f91b8f921bbd81abcb37648a6724ebb1db).
-
 ## Values
 
 | Key | Type | Default | Description |
@@ -120,8 +91,7 @@ If you have environment variables set from ConfigMaps or Secrets, check out `env
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
 | labels | object | `{}` |  |
-| livenessProbe.httpGet.path | string | `"/"` |  |
-| livenessProbe.httpGet.port | string | `"http"` |  |
+| livenessProbe.httpGet | object | `{"path":"/","port":"http"}` | Set `httpGet: ~` to deactivate |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.annotations | object | `{}` | Annotations to add to the PersistentVolumeClaim |
@@ -134,8 +104,7 @@ If you have environment variables set from ConfigMaps or Secrets, check out `env
 | ports[0].containerPort | int | `80` |  |
 | ports[0].name | string | `"http"` |  |
 | ports[0].protocol | string | `"TCP"` |  |
-| readinessProbe.httpGet.path | string | `"/"` |  |
-| readinessProbe.httpGet.port | string | `"http"` |  |
+| readinessProbe.httpGet | object | `{"path":"/","port":"http"}` | Set `httpGet: ~` to deactivate |
 | replicaCount | int | `1` | number of replicas |
 | resources | object | `{}` |  |
 | restartPolicy | string | `"Always"` |  |
@@ -143,11 +112,11 @@ If you have environment variables set from ConfigMaps or Secrets, check out `env
 | service.annotations | object | `{}` |  |
 | service.ip | string | `nil` |  |
 | service.loadBalancerIP | string | `nil` |  |
-| service.name | string | `"http"` | DEPRECATED: Use service.ports[*].name. Name of the port on the service. Ignored if service.ports is specified. |
-| service.port | int | `80` | DEPRECATED: Use service.ports[*].port. Port to use on the service. Ignored if service.ports is specified. |
-| service.ports | list | `[]` | List of ports. If you override it, you will have to explicitly add the default again. |
-| service.protocol | string | `"TCP"` | DEPRECATED: Use service.ports[*].protocol. Protocol to use for the target port. Ignored if service.ports is specified. |
-| service.targetPort | string | `"http"` | DEPRECATED: Use service.ports[*].targetPort. Target port on the pod. Ignored if service.ports is specified. |
+| service.ports | list | `[{"name":"http","port":80,"protocol":"TCP","targetPort":"http"}]` | List of ports. If you override it, you will have to explicitly add the default again. |
+| service.ports[0] | object | `{"name":"http","port":80,"protocol":"TCP","targetPort":"http"}` | Target port on the pod. |
+| service.ports[0].name | string | `"http"` | Name of the port on the service. |
+| service.ports[0].port | int | `80` | Port to use on the service. |
+| service.ports[0].protocol | string | `"TCP"` | Protocol to use for the target port. |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/charts/generic/README.md.gotmpl
+++ b/charts/generic/README.md.gotmpl
@@ -8,6 +8,10 @@
 {{ template "chart.sourcesSection" . }}
 {{ template "chart.requirementsSection" . }}
 
+## Upgrading
+
+See [the upgrading instructions](UPGRADING.md) for upgrades with breaking changes.
+
 ## Complex values
 
 ### env
@@ -46,38 +50,5 @@ configMap:
           - foo
           - bar
 ```
-
-## Upgrading
-
-### To 3.0.0
-
-Support for CronJobs has been removed. If you used the `isCronjob: true` flag, please migrate to `morremeyer/cronjob` in version `2.0.0 <= x < 3.0.0`.
-
-:warning: If you need open ports on your CronJob pod, this is not supported in the cronjob chart. This is a design decision as CronJobs should not have any incoming traffic.
-
-The cronjob chart is almost fully compatible with all existing configuration you have (except for `ports`), you just have to do one migration step:
-
-1. Remove the `isCronjob: true` value
-
-### To 2.0.0
-
-The format for configuration environment variables has changed and is now less verbose.
-
-Old:
-
-```yaml
-env:
-  - name: ENV_NAME
-    value: test
-```
-
-New:
-
-```yaml
-env:
-  ENV_NAME: test
-```
-
-If you have environment variables set from ConfigMaps or Secrets, check out `envValueFrom`, which was [added in 1.1.0](https://github.com/morremeyer/charts/commit/a2b767f91b8f921bbd81abcb37648a6724ebb1db).
 
 {{ template "chart.valuesSection" . }}

--- a/charts/generic/UPGRADING.md
+++ b/charts/generic/UPGRADING.md
@@ -1,0 +1,67 @@
+# Upgrading
+
+## 3.8.0 to 4.0.0
+
+### Kubernetes Version
+
+If you set `ingress.enabled: true`, this chart is only compatible with Kubernetes 1.21 and newer.
+
+### Service Ports
+
+The port configuration for the `service` key has been deprecated with `3.6.0` and is now removed.
+
+**If you did not change the default configuration, you do not need to do anything**
+
+Migration example:
+
+_Old_:
+
+```yaml
+service:
+  targetPort: http
+  protocol: TCP
+  name: http
+  port: 80
+```
+
+_New_:
+
+```yaml
+service:
+  ports:
+    - targetPort: http
+      protocol: TCP
+      name: http
+      port: 80
+```
+
+### To 3.0.0
+
+Support for CronJobs has been removed. If you used the `isCronjob: true` flag, please migrate to `morremeyer/cronjob` in version `2.0.0 <= x < 3.0.0`.
+
+:warning: If you need open ports on your CronJob pod, this is not supported in the cronjob chart. This is a design decision as CronJobs should not have any incoming traffic.
+
+The cronjob chart is almost fully compatible with all existing configuration you have (except for `ports`), you just have to do one migration step:
+
+1. Remove the `isCronjob: true` value
+
+### To 2.0.0
+
+The format for configuration environment variables has changed and is now less verbose.
+
+Old:
+
+```yaml
+env:
+  - name: ENV_NAME
+    value: test
+```
+
+New:
+
+```yaml
+env:
+  ENV_NAME: test
+```
+
+If you have environment variables set from ConfigMaps or Secrets, check out `envValueFrom`, which was [added in 1.1.0](https://github.com/morremeyer/charts/commit/a2b767f91b8f921bbd81abcb37648a6724ebb1db).

--- a/charts/generic/templates/ingress.yaml
+++ b/charts/generic/templates/ingress.yaml
@@ -1,13 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "generic.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/generic/templates/service.yaml
+++ b/charts/generic/templates/service.yaml
@@ -11,13 +11,6 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  {{- /* Include the deprecated settings if .Values.service.ports is empty */}}
-  {{- if not .Values.service.ports }}
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
-      protocol: {{ .Values.service.protocol }}
-      name: {{ .Values.service.name }}
-  {{- end }}
   {{- range .Values.service.ports }}
     - port: {{ .port }}
       targetPort: {{ .targetPort }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -85,11 +85,13 @@ ports:
     protocol: TCP
 
 livenessProbe:
+  # -- Set `httpGet: ~` to deactivate
   httpGet:
     path: /
     port: http
 
 readinessProbe:
+  # -- Set `httpGet: ~` to deactivate
   httpGet:
     path: /
     port: http
@@ -101,21 +103,16 @@ service:
   type: ClusterIP
   annotations: {}
 
-  # -- DEPRECATED: Use service.ports[*].targetPort. Target port on the pod. Ignored if service.ports is specified.
-  targetPort: http
-  # -- DEPRECATED: Use service.ports[*].protocol. Protocol to use for the target port. Ignored if service.ports is specified.
-  protocol: TCP
-  # -- DEPRECATED: Use service.ports[*].name. Name of the port on the service. Ignored if service.ports is specified.
-  name: http
-  # -- DEPRECATED: Use service.ports[*].port. Port to use on the service. Ignored if service.ports is specified.
-  port: 80
-
   # -- List of ports. If you override it, you will have to explicitly add the default again.
-  ports: []  # TODO: Add default port and documentation.
-    # - targetPort: http
-    #   protocol: TCP
-    #   name: http
-    #   port: 80
+  ports:
+      # -- Target port on the pod.
+    - targetPort: http
+      # -- Protocol to use for the target port.
+      protocol: TCP
+      # -- Name of the port on the service.
+      name: http
+      # -- Port to use on the service.
+      port: 80
 
   # Only for type ClusterIP
   ip: ~

--- a/charts/mailtrain/Chart.yaml
+++ b/charts/mailtrain/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: mailtrain
 description: Runs mailtrain in your kubernetes cluster
 type: application
-version: 1.2.3
+version: 2.0.0
 maintainers:
   - name: morremeyer
-    email: charts@mor.re

--- a/charts/mailtrain/README.md
+++ b/charts/mailtrain/README.md
@@ -1,6 +1,6 @@
 # mailtrain
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Runs mailtrain in your kubernetes cluster
 
@@ -8,7 +8,11 @@ Runs mailtrain in your kubernetes cluster
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| morremeyer | <charts@mor.re> |  |
+| morremeyer |  |  |
+
+## Upgrading
+
+See [the upgrading instructions](UPGRADING.md) for upgrades with breaking changes.
 
 ## Values
 

--- a/charts/mailtrain/README.md.gotmpl
+++ b/charts/mailtrain/README.md.gotmpl
@@ -7,4 +7,9 @@
 {{ template "chart.maintainersSection" . }}
 {{ template "chart.sourcesSection" . }}
 {{ template "chart.requirementsSection" . }}
+
+## Upgrading
+
+See [the upgrading instructions](UPGRADING.md) for upgrades with breaking changes.
+
 {{ template "chart.valuesSection" . }}

--- a/charts/mailtrain/UPGRADING.md
+++ b/charts/mailtrain/UPGRADING.md
@@ -1,0 +1,7 @@
+# Upgrading
+
+## 1.2.3 to 2.0.0
+
+### Kubernetes Version
+
+If you set `ingress.enabled: true`, this chart is only compatible with Kubernetes 1.21 and newer.

--- a/charts/mailtrain/templates/ingress.yaml
+++ b/charts/mailtrain/templates/ingress.yaml
@@ -1,13 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mailtrain.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
* Drops support for old Kubernetes versions
* Removes deprecated configuration
* documents deactivation of probes in the generic chart