### PR TITLE
chore!: drop EOL Kubernetes versions

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 2.1.1
+version: 3.0.0
 maintainers:
   - name: morremeyer
     email: charts@mor.re

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -9,6 +9,10 @@ Run jobs on a schedule
 | Name | Email | Url |
 | ---- | ------ | --- |
 | morremeyer | <charts@mor.re> |  |
+
+## Upgrades
+
+For upgrade instructions for breaking changes, see [UPGRADING.md](UPGRADING.md).
 
 ## Complex values
 

--- a/charts/cronjob/README.md.gotmpl
+++ b/charts/cronjob/README.md.gotmpl
@@ -8,6 +8,10 @@
 {{ template "chart.sourcesSection" . }}
 {{ template "chart.requirementsSection" . }}
 
+## Upgrades
+
+For upgrade instructions for breaking changes, see [UPGRADING.md](UPGRADING.md).
+
 ## Complex values
 
 ### env

--- a/charts/cronjob/UPGRADING.md
+++ b/charts/cronjob/UPGRADING.md
@@ -1,0 +1,7 @@
+# Upgrading
+
+## 2.1.1 to 3.0.0
+
+With 3.0.0, we dropped support for Kubernetes versions < 1.21.0.
+
+To use the chart, you will need to upgrade to at least 1.21.0.

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -1,8 +1,4 @@
-{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
-{{- else -}}
-apiVersion: batch/v1beta1
-{{- end }}
 kind: CronJob
 metadata:
   name: {{ include "cronjob.fullname" . }}


### PR DESCRIPTION
BREAKING CHANGE: Removes support for Kubernetes versions < 1.21.0
