### PR TITLE
fix!: require setting of service port name

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 4.0.0
+version: 5.0.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 
@@ -84,10 +84,9 @@ configMap:
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `nil` | The ingressClassName for this Ingress resource |
 | ingress.enabled | bool | `false` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths[0].backend.serviceName | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths[0].backend.servicePort | int | `80` |  |
-| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0] | object | `{"host":"chart-example.local","paths":[{"path":"/","servicePortName":"http"}]}` | host name to listen to |
+| ingress.hosts[0].paths[0] | object | `{"path":"/","servicePortName":"http"}` | URL path |
+| ingress.hosts[0].paths[0].servicePortName | string | `"http"` | Name of the target port on the service |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
 | labels | object | `{}` |  |

--- a/charts/generic/UPGRADING.md
+++ b/charts/generic/UPGRADING.md
@@ -1,6 +1,56 @@
 # Upgrading
 
+## 3.8.0 to 5.0.0
+
+You must now set the `ingress.hosts[*].paths[*].servicePortName`. As with 4.0.0, all ports must be configured explicitly,
+therefore it is a deliberate change that you cannot set a service port number for an Ingress resource: Naming ports is a good practice.
+
+The `servicePortName` must be set to an `service.ports[*].name` to work.
+
+**If you do not use an Ingress, you do not need to do anything**
+
+Migration example:
+
+_Old_:
+
+```yaml
+service:
+  targetPort: http
+  protocol: TCP
+  name: http
+  port: 80
+
+ingress:
+  enabled: true
+  hosts:
+    - host: example.com
+      paths:
+        - path: /
+```
+
+_New_:
+
+```yaml
+service:
+  ports:
+    - targetPort: http
+      protocol: TCP
+      name: http
+      port: 80
+
+ingress:
+  enabled: true
+  hosts:
+    - host: example.com
+      paths:
+        - path: /
+          # The servicePortName must be set now
+          servicePortName: http
+```
+
 ## 3.8.0 to 4.0.0
+
+:warning: Release 4.0.0 has a configuration-breaking bug when using `ingress: true`. Please upgrade to 5.0.0 directly.
 
 ### Kubernetes Version
 

--- a/charts/generic/templates/ingress.yaml
+++ b/charts/generic/templates/ingress.yaml
@@ -1,10 +1,8 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "generic.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "generic.fullname" . }}
   labels:
     {{- include "generic.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -32,19 +30,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
             pathType: ImplementationSpecific
-            {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
-                name: {{ $fullName }}
+                name: {{ include "generic.fullname" $ }}
                 port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
+                  name: {{ .servicePortName }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -129,12 +129,13 @@ ingress:
   annotations: {}
 
   hosts:
+      # -- host name to listen to
     - host: chart-example.local
       paths:
+          # -- URL path
         - path: /
-          backend:
-            serviceName: chart-example.local
-            servicePort: 80
+          # -- Name of the target port on the service
+          servicePortName: http
   tls: []
 
 resources: {}


### PR DESCRIPTION
The service port in `{{- $svcPort := .Values.service.port -}}` does not exist
anymore since 4.0.0.

Therefore, the `port.number` for ingresses was empty. As enabling the specification
of multiple ports requires the specification of ports on the ingress, this is now
required in the chart.

BREAKING CHANGE: You must now set ingress.hosts[*].paths[*].servicePortName.
