### PR TITLE
feat: add automated updating of CRDs and commiting of helm-docs

### DIFF
--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -2,9 +2,6 @@ name: Helm Docs
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   helm-docs:
@@ -13,6 +10,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.REPO_PACKAGES_TOKEN }}
 
       - uses: actions/setup-go@v3
         with:
@@ -26,11 +24,11 @@ jobs:
       - name: regenerate documentation
         run: $HOME/go/bin/helm-docs
 
-      # This is commented for now as it does not trigger new runs due to the push
-      # coming from an action
-      # - name: Commit updated docs
-      #   uses: EndBug/add-and-commit@v8
-      #   with:
-      #     message: "docs: regenerate chart README.md"
-      #     add: "charts/**/README.md"
-      #     pull: "--rebase --autostash"
+      - name: Commit updated docs
+        uses: EndBug/add-and-commit@v9.1.0
+        with:
+          message: "docs: regenerate chart README.md"
+          add: "charts/**/README.md"
+          pull: "--rebase --autostash"
+          author_name: Morre's Bot
+          author_email: morremeyer-bot@maurice-meyer.de

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -1,7 +1,7 @@
 name: Validate renovate config
 
 on:
-  push:
+  pull_request:
     paths:
       - renovate.json
 

--- a/.github/workflows/update-kube-prometheus-stack-crds.yml
+++ b/.github/workflows/update-kube-prometheus-stack-crds.yml
@@ -1,0 +1,45 @@
+name: Update kube-prometheus-stack CRDs
+
+on:
+  pull_request:
+    paths:
+      - charts/kube-prometheus-stack-crds/Chart.yaml
+
+jobs:
+  update-crds:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.REPO_PACKAGES_TOKEN }}
+
+      - name: Remove CRDs
+        run: rm charts/kube-prometheus-stack-crds/templates/*
+
+      - name: Get current chart version
+        id: chart_version
+        run: |
+          echo "::set-output name=CHECKOUT_REF::$(sed '/^version:/!d;s/version: //' charts/kube-prometheus-stack-crds/Chart.yaml)"
+
+      - name: Check out prometheus-community/helm-charts
+        uses: actions/checkout@v3.0.2
+        with:
+          repository: prometheus-community/helm-charts
+          ref: "kube-prometheus-stack-${{ steps.chart_version.outputs.CHECKOUT_REF }}"
+          path: kube-prometheus-stack-upstream
+
+      - name: Copy CRDs
+        run: cp kube-prometheus-stack-upstream/charts/kube-prometheus-stack/crds/* charts/kube-prometheus-stack-crds/templates/
+
+      - name: Remove kube-prometheus-stack upstream clone
+        run: rm -r kube-prometheus-stack-upstream
+
+      - name: Commit updated CRDs
+        uses: EndBug/add-and-commit@v9.1.0
+        with:
+          message: "chore(deps): update kube-prometheus-stack CRDs"
+          add: "charts/kube-prometheus-stack-crds/templates/*"
+          pull: "--rebase --autostash"
+          author_name: Morre's Bot
+          author_email: morremeyer-bot@maurice-meyer.de

--- a/charts/kube-prometheus-stack-crds/Chart.yaml
+++ b/charts/kube-prometheus-stack-crds/Chart.yaml
@@ -3,7 +3,6 @@ name: kube-prometheus-stack-crds
 description: Deploys the kube-prometheus-stack CRDs to your cluster
 type: application
 # renovate datasource=helm registryUrl=https://prometheus-community.github.io/helm-charts depName=kube-prometheus-stack
-version: 32.4.1
+version: 33.1.0
 maintainers:
   - name: morremeyer
-    email: charts@mor.re

--- a/charts/kube-prometheus-stack-crds/README.md
+++ b/charts/kube-prometheus-stack-crds/README.md
@@ -1,6 +1,6 @@
 # kube-prometheus-stack-crds
 
-![Version: 32.4.1](https://img.shields.io/badge/Version-32.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 33.1.0](https://img.shields.io/badge/Version-33.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Deploys the kube-prometheus-stack CRDs to your cluster
 
@@ -28,5 +28,5 @@ If you use renovate, we recommend using the config below to group together updat
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| morremeyer | <charts@mor.re> |  |
+| morremeyer |  |  |
 

--- a/charts/kube-prometheus-stack-crds/templates/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack-crds/templates/crd-alertmanagerconfigs.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack-crds/templates/crd-alertmanagers.yaml
+++ b/charts/kube-prometheus-stack-crds/templates/crd-alertmanagers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack-crds/templates/crd-podmonitors.yaml
+++ b/charts/kube-prometheus-stack-crds/templates/crd-podmonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack-crds/templates/crd-probes.yaml
+++ b/charts/kube-prometheus-stack-crds/templates/crd-probes.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack-crds/templates/crd-prometheuses.yaml
+++ b/charts/kube-prometheus-stack-crds/templates/crd-prometheuses.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack-crds/templates/crd-prometheusrules.yaml
+++ b/charts/kube-prometheus-stack-crds/templates/crd-prometheusrules.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack-crds/templates/crd-servicemonitors.yaml
+++ b/charts/kube-prometheus-stack-crds/templates/crd-servicemonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack-crds/templates/crd-thanosrulers.yaml
+++ b/charts/kube-prometheus-stack-crds/templates/crd-thanosrulers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.54.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchManagers": ["regex"],
       "matchPaths": ["(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$"]
+    },
+    {
+      "description": "Automerge all kube-prometheus-stack updates for the CRD chart",
+      "matchPackageNames": ["kube-prometheus-stack"],
+      "automerge": true
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
This should automatically update the CRDs and push the helm docs changes.

The `REPO_PACKAGES_TOKEN` secret is a PAT for @morremeyer-bot which leads to the commits triggering other pipelines, in this case the linting and helm-docs.

@ekeih For the review, please verify that all necessary checks are running for all commits, see https://github.com/morremeyer/charts/pull/125/commits.