### PR TITLE
fix: restartPolicy must be Never

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backup
 description: Chart to back up PVCs with restic and regularly clean up the snapshots.
 type: application
-version: 3.0.0
+version: 3.0.1
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/backup/README.md
+++ b/charts/backup/README.md
@@ -1,6 +1,6 @@
 # backup
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart to back up PVCs with restic and regularly clean up the snapshots.
 
@@ -61,7 +61,6 @@ The following table lists the configurable parameters of the chart and the defau
 | backupJob.init | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"restic/restic","tag":"0.14.0"},"resources":{}}` | Configuration for the repository init container |
 | backupJob.init.resources | object | `{}` | resources for the init container |
 | backupJob.nodeSelector | object | `{}` |  |
-| backupJob.restartPolicy | string | `"OnFailure"` | restartPolicy for the backup Jobs |
 | backupJob.schedule | string | `"17 3 * * *"` | when to run backups |
 | backupJob.securityContext | object | `{}` |  |
 | backupJob.successfulJobsHistoryLimit | int | `3` | successfulJobsHistoryLimit for the backup Jobs |
@@ -81,7 +80,6 @@ The following table lists the configurable parameters of the chart and the defau
 | cleanupJob.keepYearly | int | `2` | number of yearly snapshots to keep |
 | cleanupJob.nodeSelector | object | `{}` |  |
 | cleanupJob.resources | object | `{}` | resources for the cleanup container |
-| cleanupJob.restartPolicy | string | `"OnFailure"` | restartPolicy for the cleanup Jobs |
 | cleanupJob.schedule | string | `"17 15 * * *"` | when to run the cleanup |
 | cleanupJob.securityContext | object | `{}` |  |
 | cleanupJob.successfulJobsHistoryLimit | int | `3` | successfulJobsHistoryLimit for the cleanup Jobs |

--- a/charts/backup/templates/cronjob-backup.yaml
+++ b/charts/backup/templates/cronjob-backup.yaml
@@ -84,7 +84,7 @@ spec:
             {{- if .Values.backupJob.backup.additionalVolumeMounts }}
               {{- toYaml .Values.backupJob.backup.additionalVolumeMounts | nindent 14 }}
             {{- end }}
-          restartPolicy: {{ .Values.backupJob.restartPolicy }}
+          restartPolicy: Never
           {{- with .Values.backupJob.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/backup/templates/cronjob-cleanup.yaml
+++ b/charts/backup/templates/cronjob-cleanup.yaml
@@ -81,7 +81,7 @@ spec:
             resources:
               {{- toYaml . | nindent 14 }}
             {{- end }}
-          restartPolicy: {{ .Values.cleanupJob.restartPolicy }}
+          restartPolicy: Never
           {{- with .Values.cleanupJob.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/backup/values.yaml
+++ b/charts/backup/values.yaml
@@ -23,9 +23,6 @@ backupJob:
   # -- concurrencyPolicy for the backup Jobs
   concurrencyPolicy: Forbid
 
-  # -- restartPolicy for the backup Jobs
-  restartPolicy: OnFailure
-
   nodeSelector: {}
 
   tolerations: []
@@ -96,9 +93,6 @@ cleanupJob:
 
   # -- concurrencyPolicy for the cleanup Jobs
   concurrencyPolicy: Forbid
-
-  # -- restartPolicy for the cleanup Jobs
-  restartPolicy: OnFailure
 
   image:
     repository: restic/restic


### PR DESCRIPTION
The restartPolicy for the pods must be Never so that the Job controller
creates a new Pod when there is a fail.

With OnFailure, the Job controller deletes the Pod and the Job is failed,
with no chance to debug the failed Pod.
