### PR TITLE
feat: implement templating for sftpConfig-Values

### DIFF
--- a/charts/backup/Chart.yaml
+++ b/charts/backup/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backup
 description: Chart to back up PVCs with restic and regularly clean up the snapshots.
 type: application
-version: 3.0.1
+version: 3.1.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/backup/README.md
+++ b/charts/backup/README.md
@@ -1,6 +1,6 @@
 # backup
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart to back up PVCs with restic and regularly clean up the snapshots.
 
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the chart and the defau
 | backupJob.securityContext | object | `{}` |  |
 | backupJob.successfulJobsHistoryLimit | int | `3` | successfulJobsHistoryLimit for the backup Jobs |
 | backupJob.tolerations | list | `[]` |  |
+| cleanupJob.additionalVolumeMounts | list | `[]` | Additional volumes to mount to the restic container, e.g. to backup hostPaths. |
 | cleanupJob.affinity | object | `{}` |  |
 | cleanupJob.args | list | `[]` | arguments for the cleanup. **Automatically generated, only set when necessary** |
 | cleanupJob.command | string | `nil` | command for the cleanup. Defaults to '/usr/bin/restic' by the upstream container. |
@@ -91,3 +92,5 @@ The following table lists the configurable parameters of the chart and the defau
 | pvc | string | `nil` |  |
 | repo | string | `nil` | The repository location |
 | secretName | string | `"backup-secret"` | The secret that all containers load their environment from. See https://restic.readthedocs.io/en/latest/040_backup.html#environment-variables for variables. |
+| sftpConfig.knownHosts | list | `[]` | Deployed as ConfigMap and mounted to /etc/ssh/ssh_known_hosts |
+| sftpConfig.privateKeys.existingSecret | string | `nil` | Mounted to /root/.ssh/ |

--- a/charts/backup/templates/cronjob-backup.yaml
+++ b/charts/backup/templates/cronjob-backup.yaml
@@ -33,12 +33,31 @@ spec:
             args:
               - -c
               - "restic -r {{ .Values.repo }} unlock || restic -r {{ .Values.repo }} init"
+            {{- with .Values.backupJob.env }}
+            env:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             envFrom:
               - secretRef:
                   name: {{ .Values.secretName }}
             {{- with .Values.backupJob.init.resources }}
             resources:
               {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- if or .Values.backupJob.backup.additionalVolumeMounts .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.existingSecret }}
+            volumeMounts:
+            {{- if .Values.sftpConfig.knownHosts }}
+              - mountPath: "/etc/ssh/ssh_known_hosts"
+                name: sftp-known-hosts
+                subPath: known_hosts
+            {{- end }}
+            {{- if .Values.sftpConfig.privateKeys.existingSecret }}
+              - mountPath: "/root/.ssh"
+                name: sftp-private-keys
+            {{- end }}
+            {{- if .Values.backupJob.backup.additionalVolumeMounts }}
+              {{- toYaml .Values.backupJob.backup.additionalVolumeMounts | nindent 14 }}
+            {{- end }}
             {{- end }}
           containers:
           - name: backup
@@ -74,12 +93,21 @@ spec:
             resources:
               {{- toYaml . | nindent 14 }}
             {{- end }}
-            {{- if or .Values.pvc .Values.backupJob.backup.additionalVolumeMounts }}
+            {{- if or .Values.pvc .Values.backupJob.backup.additionalVolumeMounts .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.existingSecret}}
             volumeMounts:
             {{- end }}
             {{- if .Values.pvc }}
               - mountPath: "/data"
                 name: data
+            {{- end }}
+            {{- if .Values.sftpConfig.knownHosts }}
+              - mountPath: "/etc/ssh/ssh_known_hosts"
+                name: sftp-known-hosts
+                subPath: known_hosts
+            {{- end }}
+            {{- if .Values.sftpConfig.privateKeys.existingSecret }}
+              - mountPath: "/root/.ssh/"
+                name: sftp-private-keys
             {{- end }}
             {{- if .Values.backupJob.backup.additionalVolumeMounts }}
               {{- toYaml .Values.backupJob.backup.additionalVolumeMounts | nindent 14 }}
@@ -107,13 +135,24 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.pvc .Values.backupJob.additionalVolumes }}
+          {{- if or .Values.pvc .Values.backupJob.additionalVolumes .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.existingSecret}}
           volumes:
+          {{- end }}
+          {{- if .Values.sftpConfig.knownHosts }}
+            - name: sftp-known-hosts
+              configMap:
+                name: {{ include "backup.fullname" . }}-known-hosts
           {{- end }}
           {{- if .Values.pvc }}
             - name: data
               persistentVolumeClaim:
                 claimName: {{ .Values.pvc }}
+          {{- end }}
+          {{- if .Values.sftpConfig.privateKeys.existingSecret }}
+            - name: sftp-private-keys
+              secret:
+                secretName: {{ .Values.sftpConfig.privateKeys.existingSecret }}
+                defaultMode: 0400
           {{- end }}
           {{- if .Values.backupJob.additionalVolumes }}
             {{- toYaml .Values.backupJob.additionalVolumes | nindent 12 }}

--- a/charts/backup/templates/cronjob-cleanup.yaml
+++ b/charts/backup/templates/cronjob-cleanup.yaml
@@ -34,12 +34,31 @@ spec:
             args:
               - -c
               - "restic -r {{ .Values.repo }} unlock"
+            {{- with .Values.cleanupJob.env }}
+            env:
+              {{- toYaml . | nindent 14}}
+            {{- end }}
             envFrom:
               - secretRef:
                   name: {{ .Values.secretName }}
             {{- with .Values.cleanupJob.resources }}
             resources:
               {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- if or .Values.cleanupJob.additionalVolumeMounts .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.existingSecret}}
+            volumeMounts:
+            {{- if .Values.sftpConfig.knownHosts }}
+              - mountPath: "/etc/ssh/ssh_known_hosts"
+                name: sftp-known-hosts
+                subPath: known_hosts
+            {{- end }}
+            {{- if .Values.sftpConfig.privateKeys.existingSecret }}
+              - mountPath: "/root/.ssh"
+                name: sftp-private-keys
+            {{- end }}
+            {{- if .Values.cleanupJob.additionalVolumeMounts }}
+              {{- toYaml .Values.cleanupJob.additionalVolumeMounts | nindent 14 }}
+            {{- end }}
             {{- end }}
           containers:
           - name: cleanup
@@ -77,9 +96,28 @@ spec:
             envFrom:
               - secretRef:
                   name: {{ .Values.secretName }}
+            {{- with .Values.cleanupJob.env }}
+            env:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             {{- with .Values.cleanupJob.resources }}
             resources:
               {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- if or .Values.cleanupJob.additionalVolumeMounts .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.existingSecret}}
+            volumeMounts:
+            {{- if .Values.sftpConfig.knownHosts }}
+              - mountPath: "/etc/ssh/ssh_known_hosts"
+                name: sftp-known-hosts
+                subPath: known_hosts
+            {{- end }}
+            {{- if .Values.sftpConfig.privateKeys.existingSecret }}
+              - mountPath: "/root/.ssh/"
+                name: sftp-private-keys
+            {{- end }}
+            {{- if .Values.cleanupJob.additionalVolumeMounts }}
+              {{- toYaml .Values.cleanupJob.additionalVolumeMounts | nindent 14 }}
+            {{- end }}
             {{- end }}
           restartPolicy: Never
           {{- with .Values.cleanupJob.nodeSelector }}
@@ -102,5 +140,22 @@ spec:
           {{- with .Values.cleanupJob.tolerations }}
           tolerations:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.cleanupJob.additionalVolumes .Values.sftpConfig.knownHosts .Values.sftpConfig.privateKeys.existingSecret }}
+          volumes:
+          {{- if .Values.sftpConfig.knownHosts }}
+            - name: sftp-known-hosts
+              configMap:
+                name: {{ include "backup.fullname" . }}-known-hosts
+          {{- end }}
+          {{- if .Values.sftpConfig.privateKeys.existingSecret }}
+            - name: sftp-private-keys
+              secret:
+                secretName: {{ .Values.sftpConfig.privateKeys.existingSecret }}
+                defaultMode: 0400
+          {{- end }}
+          {{- if .Values.cleanupJob.additionalVolumes }}
+            {{- toYaml .Values.cleanupJob.additionalVolumes | nindent 12 }}
+          {{- end }}
           {{- end }}
 {{- end }}

--- a/charts/backup/templates/sftp-known_hosts.yaml
+++ b/charts/backup/templates/sftp-known_hosts.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sftpConfig.knownHosts -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "backup.fullname" . }}-known-hosts
+  namespace: {{ .Release.namespace }}
+  labels:
+    {{- include "backup.labels" . | nindent 4 }}
+data:
+  known_hosts: |
+    {{- range .Values.sftpConfig.knownHosts }}
+    {{ . | indent 2 | trim }}
+    {{- end }}
+{{- end }}

--- a/charts/backup/values.yaml
+++ b/charts/backup/values.yaml
@@ -13,6 +13,13 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+sftpConfig:
+  # -- Deployed as ConfigMap and mounted to /etc/ssh/ssh_known_hosts
+  knownHosts: []
+  privateKeys:
+    # -- Mounted to /root/.ssh/
+    existingSecret: ~
+
 backupJob:
   # -- Additional environment values to load. Only applies to the backup container, not the init containers that initializes the restic repository. Has to match the pod.spec.containers.env spec.
   env: []
@@ -107,6 +114,9 @@ cleanupJob:
 
   # -- resources for the cleanup container
   resources: {}
+
+  # -- Additional volumes to mount to the restic container, e.g. to backup hostPaths.
+  additionalVolumeMounts: []
 
   nodeSelector: {}
 


### PR DESCRIPTION
This provides a way of configuring resources for sftp-repositories using ppk-auth.

Contians a fix for env-variables configured in values to be deployed in the backup- and cleanup-jobs.

Supersedes #99.
