### PR TITLE
fix(cronjob): fix configuration of cronjob resources

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 3.0.1
+version: 3.0.2
 maintainers:
   - name: morremeyer
-    email: charts@mor.re
+  - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -8,7 +8,8 @@ Run jobs on a schedule
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| morremeyer | <charts@mor.re> |  |
+| morremeyer |  |  |
+| ekeih |  |  |
 
 ## Upgrades
 

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -85,7 +85,7 @@ spec:
               {{- end }}
               {{- end }}
               {{- with .Values.resources }}
-              resources: {{- toYaml .Values.resources | nindent 16 }}
+              resources: {{- toYaml . | nindent 16 }}
               {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector: {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Thanks @ximena9201 for reporting this issue.

Setting resources for cronjobs never worked, this fixes it.


(I wrote a very long commit message with the error message and an explanation, but pre-commit deleted the whole commit message because the line with the error message was longer than 100 characters... do we really need that rule?)