### PR TITLE
chore: migrate deprecated GitHub actions output syntax

### DIFF
--- a/.github/workflows/lint-and-release.yml
+++ b/.github/workflows/lint-and-release.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/update-kube-prometheus-stack-crds.yml
+++ b/.github/workflows/update-kube-prometheus-stack-crds.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get current chart version
         id: chart_version
         run: |
-          echo "::set-output name=CHECKOUT_REF::$(sed '/^version:/!d;s/version: //' charts/kube-prometheus-stack-crds/Chart.yaml)"
+          echo "CHECKOUT_REF=$(sed '/^version:/!d;s/version: //' charts/kube-prometheus-stack-crds/Chart.yaml)" >> $GITHUB_OUTPUT
 
       - name: Check out prometheus-community/helm-charts
         uses: actions/checkout@v3.3.0

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
-  rules: {},
+  rules: {
+    "body-max-line-length": [0, "always", 200],
+  },
 };


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
