### PR TITLE
fix: missing capture for hetznercloud/hcloud-cloud-controller-manager in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
     },
     {
       "matchPackageNames": ["hetznercloud/hcloud-cloud-controller-manager"],
-      "extractVersion": "^v(?<version>)"
+      "extractVersion": "^v(?<version>.*)$"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
This adds the missing capture for the `extractVersion` for `hetznercloud/hcloud-cloud-controller-manager`.

Should fix the following renovate problem:

```
Found no results from datasource that look like a version (hetznercloud/hcloud-cloud-controller-manager)
```
