### PR TITLE
feat: enable API access configuration

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjob
 description: Run jobs on a schedule
 type: application
-version: 3.0.5
+version: 3.1.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -1,6 +1,6 @@
 # cronjob
 
-![Version: 3.0.5](https://img.shields.io/badge/Version-3.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Run jobs on a schedule
 
@@ -62,6 +62,9 @@ configMap:
 | additionalVolumes | list | `[]` |  |
 | affinity | object | `{}` | affinity object for the pod |
 | annotations | object | `{}` |  |
+| apiAccess | object | `{"enabled":false,"rules":[]}` | Configuration for access to the Kubernetes API |
+| apiAccess.enabled | bool | `false` | When set to true, a Role and RoleBinding are deployed that give access with the rules defined in apiAccess.rules |
+| apiAccess.rules | list | `[]` | Rules for the API access of the ServiceAccount used by the CronJob pods. Check [the documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) for more information |
 | args | list | `[]` | arguments to pass to the command or binary being run |
 | command | list | `[]` | the command or binary to run |
 | configMap.data | object | `{}` | The data for the ConfigMap. Both keys and values need to be strings. |

--- a/charts/cronjob/ci/roles-values.yaml
+++ b/charts/cronjob/ci/roles-values.yaml
@@ -1,0 +1,6 @@
+apiAccess:
+  enabled: true
+  rules:
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "list"]

--- a/charts/cronjob/templates/role.yaml
+++ b/charts/cronjob/templates/role.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.apiAccess.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cronjob.fullname" . }}
+  labels:
+    {{- include "cronjob.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules: {{ toYaml .Values.apiAccess.rules | nindent 2 }}
+{{- end }}

--- a/charts/cronjob/templates/roleBinding.yaml
+++ b/charts/cronjob/templates/roleBinding.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.apiAccess.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cronjob.fullname" . }}
+  labels:
+    {{- include "cronjob.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cronjob.serviceAccountName" . }}
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ include "cronjob.fullname" . }}
+  apiGroup: ""
+{{- end }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -98,3 +98,12 @@ tolerations: []
 
 # -- affinity object for the pod
 affinity: {}
+
+# -- Configuration for access to the Kubernetes API
+apiAccess:
+
+  # -- When set to true, a Role and RoleBinding are deployed that give access with the rules defined in apiAccess.rules
+  enabled: false
+
+  # -- Rules for the API access of the ServiceAccount used by the CronJob pods. Check [the documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) for more information
+  rules: []


### PR DESCRIPTION
Enables configuration for Kubernetes API access from the CronJob itself.
