### PR TITLE
feat: make terminationGracePeriodSeconds configurable

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 5.4.1
+version: 5.5.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 5.4.1](https://img.shields.io/badge/Version-5.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.5.0](https://img.shields.io/badge/Version-5.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 
@@ -133,4 +133,5 @@ configMap:
 | serviceMonitors[0].port | string | `"http"` | The port to scrape |
 | serviceMonitors[0].scrapeTimeout | string | `"10s"` | Timeout for scraping |
 | startupProbe | string | `nil` | Configure a startup probe for the pod |
+| terminationGracePeriodSeconds | int | `30` | How long the pod may take to terminate before it is killed by the kubelet |
 | tolerations | list | `[]` |  |

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -63,6 +63,7 @@ spec:
       {{- with .Values.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -36,6 +36,9 @@ podSecurityContext: {}
 
 securityContext: {}
 
+# -- How long the pod may take to terminate before it is killed by the kubelet
+terminationGracePeriodSeconds: 30
+
 # -- Set to true to enable host networking
 hostNetwork: false
 


### PR DESCRIPTION
This makes the `terminationGracePeriodSeconds` configurable.

It defaults to the Kubernetes default of 30 seconds.
