### PR TITLE
feat!: add default node and zone spread affinities

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 5.6.0
+version: 6.0.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 5.6.0](https://img.shields.io/badge/Version-5.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 
@@ -68,9 +68,10 @@ configMap:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalPreferredPodAntiAffinity | object | `{}` | Additional preferredDuringSchedulingIgnoredDuringExecution podAntiAffinity terms |
 | additionalVolumeMounts | list | `[]` |  |
 | additionalVolumes | list | `[]` |  |
-| affinity | object | `{}` |  |
+| affinity | object | `{}` | Additional affinity terms. **Do not** specify PodAntiAffinities with preferredDuringSchedulingIgnoredDuringExecution here, these go to `additionalPreferredPodAntiAffinity`. |
 | annotations | object | `{}` |  |
 | args | string | `nil` |  |
 | autoscaling.enabled | bool | `false` |  |
@@ -85,6 +86,8 @@ configMap:
 | deploymentStrategy | object | `{}` |  |
 | dnsConfig | object | `{}` | Optional DNS settings |
 | dnsPolicy | string | `nil` | Defaults to "ClusterFirst" if hostNetwork is false and "ClusterFirstWithHostNet" if hostNetwork is true. |
+| enableNodeSpreadPodAntiAffinity | bool | `true` | Enable an AntiAffinity between pods, spreading them across nodes if possible with a priority of 100. |
+| enableZoneSpreadPodAntiAffinity | bool | `false` | Enable an AntiAffinity between pods, spreading them across zones if possible with a priority of 50. |
 | env | list | `[]` | Directly set environment variables |
 | envFrom | list | `[]` | Directly set envFrom config |
 | envValueFrom | object | `{}` | Set environment variables from configMaps or Secrets |

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -71,7 +71,7 @@ configMap:
 | additionalPreferredPodAntiAffinity | object | `{}` | Additional preferredDuringSchedulingIgnoredDuringExecution podAntiAffinity terms |
 | additionalVolumeMounts | list | `[]` |  |
 | additionalVolumes | list | `[]` |  |
-| affinity | object | `{}` | Additional affinity terms. **Do not** specify PodAntiAffinities with preferredDuringSchedulingIgnoredDuringExecution here, these go to `additionalPreferredPodAntiAffinity`. |
+| affinity | object | `{}` | Additional affinity terms. **Do not** specify PodAntiAffinities with preferredDuringSchedulingIgnoredDuringExecution here, these go to `additionalPreferredPodAntiAffinity`. All `requiredDuringScheduling` affinities need to be defined here. |
 | annotations | object | `{}` |  |
 | args | string | `nil` |  |
 | autoscaling.enabled | bool | `false` |  |

--- a/charts/generic/ci/affinity-values.yaml
+++ b/charts/generic/ci/affinity-values.yaml
@@ -1,0 +1,22 @@
+enableNodeSpreadPodAntiAffinity: true
+enableZoneSpreadPodAntiAffinity: true
+
+additionalPreferredPodAntiAffinity:
+  - weight: 100
+    podAffinityTerm:
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: some-app
+          app.kubernetes.io/name: release-name
+      topologyKey: kubernetes.io/hostname
+
+affinity:
+  podAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 70
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: some-other-component
+              app.kubernetes.io/name: nextcloud
+          topologyKey: kubernetes.io/hostname

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -130,8 +130,40 @@ spec:
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.affinity .Values.additionalPreferredPodAntiAffinity .Values.enableNodeSpreadPodAntiAffinity .Values.enableZoneSpreadPodAntiAffinity }}
+      affinity:
+      {{- if or .Values.additionalPreferredPodAntiAffinity .Values.enableNodeSpreadPodAntiAffinity .Values.enableZoneSpreadPodAntiAffinity }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+      {{- if .Values.enableNodeSpreadPodAntiAffinity }}
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "generic.labels" . | nindent 20 }}
+                    {{- with .Values.labels }}
+                    {{- toYaml . | nindent 20 }}
+                    {{- end }}
+                topologyKey: kubernetes.io/hostname
+      {{- end }}
+      {{- if .Values.enableZoneSpreadPodAntiAffinity }}
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "generic.labels" . | nindent 20 }}
+                    {{- with .Values.labels }}
+                    {{- toYaml . | nindent 20 }}
+                    {{- end }}
+                topologyKey: topology.kubernetes.io/zone
+      {{- end }}
+      {{- with .Values.additionalPreferredPodAntiAffinity }}
+      {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- end }}
       {{- with .Values.affinity }}
-      affinity: {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -196,5 +196,5 @@ enableZoneSpreadPodAntiAffinity: false
 # -- Additional preferredDuringSchedulingIgnoredDuringExecution podAntiAffinity terms
 additionalPreferredPodAntiAffinity: {}
 
-# -- Additional affinity terms. **Do not** specify PodAntiAffinities with preferredDuringSchedulingIgnoredDuringExecution here, these go to `additionalPreferredPodAntiAffinity`.
+# -- Additional affinity terms. **Do not** specify PodAntiAffinities with preferredDuringSchedulingIgnoredDuringExecution here, these go to `additionalPreferredPodAntiAffinity`. All `requiredDuringScheduling` affinities need to be defined here.
 affinity: {}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -187,4 +187,14 @@ nodeSelector: {}
 
 tolerations: []
 
+# -- Enable an AntiAffinity between pods, spreading them across nodes if possible with a priority of 100.
+enableNodeSpreadPodAntiAffinity: true
+
+# -- Enable an AntiAffinity between pods, spreading them across zones if possible with a priority of 50.
+enableZoneSpreadPodAntiAffinity: false
+
+# -- Additional preferredDuringSchedulingIgnoredDuringExecution podAntiAffinity terms
+additionalPreferredPodAntiAffinity: {}
+
+# -- Additional affinity terms. **Do not** specify PodAntiAffinities with preferredDuringSchedulingIgnoredDuringExecution here, these go to `additionalPreferredPodAntiAffinity`.
 affinity: {}


### PR DESCRIPTION
BREAKING CHANGE: In this release, a new default PodAntiAffinity is deployed and
some affinities need to be migrated out of the "affinity" keyword.
