### PR TITLE
feat: add support for additional yaml objects in generic chart

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic
 description: A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 type: application
-version: 7.0.4
+version: 7.1.0
 maintainers:
   - name: morremeyer
   - name: ekeih

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,6 @@
 # generic
 
-![Version: 7.0.4](https://img.shields.io/badge/Version-7.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 7.1.0](https://img.shields.io/badge/Version-7.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A chart for generic applications. Use this if you need to deploy something without wanting to build a fully fledged new helm chart.
 
@@ -64,10 +64,25 @@ configMap:
           - bar
 ```
 
+### additionalObjects
+
+If you want to add additional objects you can deploy them with `additionalObjects`:
+
+```
+additionalObjects:
+  - apiVersion: v1
+    data:
+      custom-key: custom value
+    kind: ConfigMap
+    metadata:
+      name: additional-configmap
+```
+
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalObjects | list | `[]` | Additional API resources to deploy |
 | additionalPreferredPodAntiAffinity | object | `{}` | Additional preferredDuringSchedulingIgnoredDuringExecution podAntiAffinity terms |
 | additionalVolumeMounts | list | `[]` |  |
 | additionalVolumes | list | `[]` |  |

--- a/charts/generic/README.md.gotmpl
+++ b/charts/generic/README.md.gotmpl
@@ -61,4 +61,18 @@ configMap:
           - bar
 ```
 
+### additionalObjects
+
+If you want to add additional objects you can deploy them with `additionalObjects`:
+
+```
+additionalObjects:
+  - apiVersion: v1
+    data:
+      custom-key: custom value
+    kind: ConfigMap
+    metadata:
+      name: additional-configmap
+```
+
 {{ template "chart.valuesSection" . }}

--- a/charts/generic/ci/additionalObjects-values.yaml
+++ b/charts/generic/ci/additionalObjects-values.yaml
@@ -1,0 +1,7 @@
+additionalObjects:
+  - apiVersion: v1
+    data:
+      custom-key: custom value
+    kind: ConfigMap
+    metadata:
+      name: additional-configmap

--- a/charts/generic/templates/additionalObjects.yaml
+++ b/charts/generic/templates/additionalObjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.additionalObjects }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -208,3 +208,6 @@ podDisruptionBudget:
 
   # -- How many pods can be unvailable, maximum
   maxUnavailable: ""
+
+# -- Additional API resources to deploy
+additionalObjects: []


### PR DESCRIPTION
- fix #320
- it also adds a testcase with default values
- Wasn't sure what name we want to use for the value. Bitnami uses `extreDeploy`. But `additional` felt more aligned with our other values, so I opted for `additionalObjects`. Other options would be `additionelResources` or `additionalDeploy`.