### PR TITLE
ci: always run helm-docs on PR

### DIFF
--- a/.github/workflows/helm-docs-skip.yml
+++ b/.github/workflows/helm-docs-skip.yml
@@ -1,12 +1,11 @@
 name: Helm Docs - Skip
 
 on:
-  push:
-    branches-ignore:
-      - renovate/**
+  pull_request:
 
 jobs:
   helm-docs:
     runs-on: ubuntu-latest
+    if: ${{ github.event.repository.name != 'charts' }}
     steps:
       - run: echo "Not a renovate PR, nothing to do"

--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -1,9 +1,7 @@
 name: Helm Docs
 
 on:
-  push:
-    branches:
-      - renovate/**
+  pull_request:
 
 permissions:
   contents: write
@@ -13,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run this for PRs from the charts repo itself (to auto-update docs for renovate PRs)
     # For PRs made by humans, running pre-commit locally is required.
-    if: ${{ github.event.repository.name == "charts" }}
+    if: ${{ github.event.repository.name == 'charts' }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
         with:


### PR DESCRIPTION
Always run helm-docs on PR, just run different things depending on the source repo
