### PR TITLE
chore: fix renovate python version extraction, 2nd edition

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
     {
       "matchDatasources": ["github-tags"],
       "matchPackageNames": ["python/cpython"],
-      "extractVersion": "^(?<version>.*)$"
+      "extractVersion": "^v(?<version>.*)$"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
If you actually add the `v` you're trying to extract, it might work.
